### PR TITLE
Unexpected Identifier error fix when importing YAML files.

### DIFF
--- a/yaml.js
+++ b/yaml.js
@@ -5,5 +5,5 @@
 var jsyaml = require('js-yaml');
 
 exports.translate = function(load) {
-  return 'module.exports = ' + jsyaml.load(load.source);
+  return 'module.exports = ' + JSON.stringify(jsyaml.load(load.source));
 }


### PR DESCRIPTION
`jsymal.load` returns a Javascript Object. Object.prototype.toString returns [Object Object] string that causes Unexpected Identifier error when evaluated.
